### PR TITLE
various translations fix and improvement

### DIFF
--- a/donate.php
+++ b/donate.php
@@ -89,6 +89,7 @@ require_once __DIR__ . '/translations.php';
                     <option value="ja">日本語</option>
                     <option value="ko">한국어</option>
                     <option value="pl">Polski</option>
+                    <option value="zh-hans">中文（简体）</option>
                     <option value="zh-hant">中文（繁體）</option>
                   </select>
                 </form>

--- a/translations.php
+++ b/translations.php
@@ -35,22 +35,20 @@
 			'ko' => '소개',
 			'pl' => 'O nas',
 			'pt' => 'Sobre',
-			'zh-hans' => '关于',
-			'zh-hant' => '關於',
+			'zh-hans' => '简介',
+			'zh-hant' => '簡介',
 		],
 		'header-menu-wiki' => [
 			'en' => 'Wiki',
 			'ja' => 'ウィキ',
+			'ko' => '위키',
 		],
 		'header-menu-blog' => [
 			'en' => 'Blog',
 			'ja' => 'ブログ',
-			'ko' => '위키',
-			'zh-hant' => '網誌',
-		],
-		'header-menu-blog' => [
-			'en' => 'Blog',
 			'ko' => '블로그',
+			'zh-hant' => '博客',
+			'zh-hant' => '網誌',
 		],
 		'header-menu-status' => [
 			'en' => 'Status',
@@ -260,8 +258,8 @@
 			'ko' => '소개',
 			'pl' => 'O nas',
 			'pt' => 'Sobre',
-			'zh-hans' => '关于',
-			'zh-hant' => '關於',
+			'zh-hans' => '简介',
+			'zh-hant' => '簡介',
 		],
 		'about-desc' => [
 			'en' => 'In July 2015, John Lewis and Ferran Tufan created a new wiki farm - named Miraheze. ' .
@@ -432,6 +430,7 @@
 			'ko' => '금액',
 			'pl' => 'Kwota',
 			'pt' => 'Montante',
+			'zh-hans' => '金额'
 			'zh-hant' => '金額',
 		],
 		'donate-note' => [

--- a/translations.php
+++ b/translations.php
@@ -430,7 +430,7 @@
 			'ko' => '금액',
 			'pl' => 'Kwota',
 			'pt' => 'Montante',
-			'zh-hans' => '金额'
+			'zh-hans' => '金额',
 			'zh-hant' => '金額',
 		],
 		'donate-note' => [


### PR DESCRIPTION
This is a follow up of #35 
I have found some errors after the pull request I mentioned is merged:
- The Korean word "위키" means "wiki" but it was put into 'header-menu-blog' instead of 'header-menu-wiki' (Use Google Translate to check this word)
- There's two 'header-menu-blog' for no reason and it causes a webpage display issue.

Also, I have made some improvement on some Chinese translations. Sorry for the additional request.