### PR TITLE
Support whitespace alongside pipes for links

### DIFF
--- a/getTranslations.php
+++ b/getTranslations.php
@@ -36,7 +36,7 @@ function getTranslation( $key ) {
 		throw new Exception( $error );
 	}
 
-	return preg_replace( '/\[(.*?)\|(.*?)\]/', '<a href="$1">$2</a>',
+	return preg_replace( '/\[(.*?)[\|| ](.*?)\]/', '<a href="$1">$2</a>',
 		nl2br( htmlspecialchars(
 			getLocalisation()[$key] ?? getFallback()[$key] ?? getDefault()[$key]
 		) )


### PR DESCRIPTION
Some of the translations decided to use space (like MediaWiki) instead of how we set it up with pipe.