### PR TITLE
use SRI when retrieving Bootstrap JS

### DIFF
--- a/components/footer.php
+++ b/components/footer.php
@@ -85,4 +85,4 @@
 	}
 </script>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"></script>


### PR DESCRIPTION
This PR adds support for using SRI when retrieving Bootstrap JS.

The hash is a SHA-384 hash created by me using OpenSSL 3.0.7. I generated it from both the Bootstrap GitHub 5.1.3 release (https://github.com/twbs/bootstrap/releases/tag/v5.1.3) and the file offered for download by jsdelivr, both returning the same hash.