### PR TITLE
Update the footer message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,7 @@
 	"features-extensions-desc": "We have designed some of the most cutting edge extensions to help us grow and become one of the world's best wiki farms! Our extensions allow communities to have more control over their own wikis, requiring little oversight from our staff. We listen to community input over the management of their wikis.",
 	"features-more-desc": "And many more features!",
 	"about-desc": "In July 2015, John Lewis and Ferran Tufan created a new wiki farm - named Miraheze. Through the use of community crowdfunding and personal investment, Miraheze officially went live in August of 2015. Over the years, the project has grown immensely to be one of the largest and most recognizable wiki farms specializing in MediaWiki on offer. Despite the success and evolution, one aspect of Miraheze never changed - formal existence. In November 2019, Miraheze became a registered not-for-profit in the UK as Miraheze Limited. In Janurary 2024 operations were transfered to WikiTide Foundation.",
-	"footer-desc": "WikiTide Foundation \n A registered 501(c)(3) nonprofit company no. 5312868 in the United States. \n Except where otherwise noted, the content of this site is licensed under a [https://creativecommons.org/licenses/by-sa/4.0/|Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)].",
+	"footer-desc": "WikiTide Foundation\nA registered 501(c)(3) nonprofit company no. 5312868 in the United States.\nExcept where otherwise noted, the content of this site is published under the [https://creativecommons.org/licenses/by-sa/4.0/ Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)] license.",
 	"footer-terms": "Terms of Use",
 	"footer-privacy-policy": "Privacy Policy",
 	"footer-content-policy": "Content Policy",


### PR DESCRIPTION
1. Make the link markup similar to standard wikitext by removing the pipe.

2. Add the "Creative Commons" name and slightly rephrase the ending.

3. Remove unnecessary whitespace, which looks a bit weird to translators on translatewiki.

Please note: This pull request is a bit less trivial than my usual patches, so please test it carefully.